### PR TITLE
docs: draft API sign-off package

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -9,10 +9,10 @@ This file maintains the persistent planning board for the React GTM Kit project.
 - **Blocked** – Requires external input or prerequisite completion.
 - **Done** – Finished and documented.
 
-| ID | Task | Status | Notes (last updated: 2025-11-05) |
+| ID | Task | Status | Notes (last updated: 2025-11-06) |
 | --- | --- | --- | --- |
 | TK-001 | Consolidate charter, scope, architecture, and governance into README for single-source documentation. | Done | Captured full project brief, requirements, and governance in README refresh. |
-| TK-002 | Freeze API surface and finalize design sign-off package (M0). | Backlog | Prep: reconfirm scope/non-goals in README with stakeholders;<br>Draft API signatures + lifecycle diagrams in `docs/design/api-signoff.md`;<br>Author governance/ownership matrix in `docs/governance/OWNERS.md`;<br>Record sign-off in `docs/design/DECISIONS.md`. |
+| TK-002 | Freeze API surface and finalize design sign-off package (M0). | Review | 2025-11-06: Drafted API sign-off doc, ownership matrix, and decision log; awaiting architecture + DX approval.<br>Prep: reconfirm scope/non-goals in README with stakeholders;<br>Draft API signatures + lifecycle diagrams in `docs/design/api-signoff.md`;<br>Author governance/ownership matrix in `docs/governance/OWNERS.md`;<br>Record sign-off in `docs/design/DECISIONS.md`. |
 | TK-003 | Implement core package alpha covering init/queue/flush, multi-container, teardown, and unit tests (M1). | Backlog | Tasks: scaffold `packages/core/` with build tooling;<br>Implement data layer manager, loader, queue, teardown utilities, logger;<br>Add Jest unit tests for init idempotency, FIFO queue, multi-container ordering, teardown;<br>Wire lint/test/build scripts in root. |
 | TK-004 | Build Consent Mode v2 API with comprehensive tests (M2). | Backlog | Steps: extend core with type-safe `consent.ts` setters mapping Google keys;<br>Cover updates before/after init and network parameter composition in tests;<br>Document usage in `docs/how-to/consent.md`. |
 | TK-005 | Deliver SSR noscript helper and CSP nonce handling with E2E coverage (M3). | Backlog | Steps: add noscript iframe generator utility;<br>Allow loader CSP nonce option for injected scripts;<br>Create Playwright E2E `e2e/csp-noscript.spec.ts` verifying nonce + noscript;<br>Document SSR/CSP setup in `docs/how-to/ssr.md`. |

--- a/docs/design/DECISIONS.md
+++ b/docs/design/DECISIONS.md
@@ -1,0 +1,15 @@
+# Decision log
+
+## 2025-11-06 – M0 API surface freeze (TK-002)
+- **Context:** Stabilize the core API before adapter implementation and downstream documentation.
+- **Decision:** Adopt the API contract defined in [`api-signoff.md`](./api-signoff.md) as the frozen surface for M1 delivery.
+  - `createGtmClient` remains the sole factory entry point with idempotent lifecycle semantics.
+  - Consent helpers (`setConsentDefaults`, `updateConsent`, namespace helpers) map 1:1 to Google Consent Mode commands.
+  - Noscript support is exposed as a pure helper returning iframe markup; no automatic DOM injection.
+  - No additional public exports will be introduced without a new review.
+- **Rationale:** Keeps adapters and docs aligned, prevents churn during multi-package rollout, and satisfies the charter’s
+  minimal-API principle.
+- **Status:** Pending stakeholder sign-off (Architecture, DX). Target review meeting: 2025-11-08.
+- **Follow-ups:**
+  - Produce architecture diagram illustrating init/queue/flush for inclusion in the sign-off packet.
+  - Capture reviewer approvals in this log once the meeting concludes.

--- a/docs/design/api-signoff.md
+++ b/docs/design/api-signoff.md
@@ -1,0 +1,138 @@
+# API sign-off – React GTM Kit core
+
+_Status: Proposed_  
+_Owner: Core engineering_  
+_Reviewers: DX, Architecture_
+
+This document freezes the public API surface for the `@react-gtm-kit/core` package ahead of milestone M1. The goal is to provide
+clear signatures, lifecycle expectations, and guardrails so adapters and documentation can rely on a stable contract.
+
+## 1. Entry points
+
+The package exposes the following named exports:
+
+| Export | Type | Purpose |
+| --- | --- | --- |
+| `createGtmClient` | `(options: CreateGtmClientOptions) => GtmClient` | Factory that returns an idempotent GTM client instance. |
+| `createNoscriptMarkup` | `(container: ContainerConfigInput \| ContainerConfigInput[], options?: NoscriptOptions) => string` | Generates standards-compliant `<noscript>` iframe markup for SSR. |
+| `DEFAULT_NOSCRIPT_IFRAME_ATTRIBUTES` | `Record<string, string>` | Baseline iframe attributes (height/width/style) used by the helper. |
+| `consent` | Namespace of typed consent helpers | Convenience entry point to call `default` and `update` commands. |
+| `buildConsentCommand` | Factory used internally by adapters | Builds a `{ command, state, options }` payload for advanced scenarios. |
+| `consentPresets` / `getConsentPreset` | Typed lookup for common regional defaults | Allows downstreams to seed consent state. |
+| Type exports | `ContainerConfigInput`, `CreateGtmClientOptions`, `GtmClient`, `ConsentState`, etc. | Compile-time surface area relied upon by adapters and apps. |
+
+No additional exports will be added without a new design review. Internal utilities (`script-manager`, `data-layer`, etc.) remain
+private to allow refactors without API churn.
+
+## 2. `createGtmClient` contract
+
+### Options shape
+
+```ts
+interface CreateGtmClientOptions {
+  containers: ContainerConfigInput[] | ContainerConfigInput; // required
+  dataLayerName?: string; // default: "dataLayer"
+  host?: string; // default: https://www.googletagmanager.com
+  defaultQueryParams?: Record<string, string | number | boolean>; // appended to every container request
+  scriptAttributes?: ScriptAttributes; // copied to injected <script>
+  logger?: PartialLogger; // overrides for debug/info/warn/error hooks
+}
+```
+
+- `containers` accepts either a GTM ID string (`"GTM-XXXX"`) or a descriptor object `{ id, queryParams? }`. Arrays are supported
+  for multi-container setups and preserve order.
+- `dataLayerName` allows advanced consumers to reuse an existing array. The client never overwrites non-array globals.
+- `host`, `defaultQueryParams`, and per-container `queryParams` enable Consent Mode + environment workflows (e.g., `gtm_auth`).
+- `scriptAttributes` covers CSP nonces, async/defer flags, and `data-*` instrumentation.
+- `logger` provides opt-in diagnostics while preserving a no-op default to avoid console noise in production.
+
+### Lifecycle and methods
+
+`createGtmClient` returns an object implementing:
+
+```ts
+interface GtmClient {
+  readonly dataLayerName: string;
+  init(): void;
+  push(value: DataLayerValue): void;
+  setConsentDefaults(state: ConsentState, options?: ConsentRegionOptions): void;
+  updateConsent(state: ConsentState, options?: ConsentRegionOptions): void;
+  teardown(): void;
+  isInitialized(): boolean;
+}
+```
+
+- **`init()`** is idempotent. Repeat calls after initialization log and exit without side-effects.
+- During `init()` the client:
+  1. Claims or creates the `dataLayer` via `ensureDataLayer`.
+  2. Pushes the standard `{ event: 'gtm.js', 'gtm.start': timestamp }` object.
+  3. Flushes any queued `push()` or consent calls performed pre-init.
+  4. Injects exactly one `<script>` per container using `ScriptManager.ensure`.
+- **`push(value)`** accepts structured objects, arrays, or callback functions per GTM’s data layer contract. Falsy values are
+  ignored with a warning. Calls pre-init are queued (FIFO) and flushed once `init()` completes.
+- **`setConsentDefaults` / `updateConsent`** wrap the Consent Mode v2 commands (`default` and `update`). Both accept a
+  `ConsentState` object with the keys `ad_storage`, `analytics_storage`, `ad_user_data`, and `ad_personalization`. Optional
+  `ConsentRegionOptions` allow scoping by region lists (`region`, `wait_for_update` windows, etc.). Values are queued if invoked
+  before `init()` to preserve ordering guarantees.
+- **`teardown()`** removes injected scripts, restores any pre-existing data layer reference, and clears the queue. This is used for
+  tests and hot-module reload scenarios.
+- **`isInitialized()`** exposes client state for adapters to coordinate StrictMode double-invocation handling.
+
+### Sequence overview
+
+```
+createGtmClient(options)
+      │
+      ▼
+client.init()
+      │
+      ├─ ensureDataLayer(name)
+      ├─ push({ event: 'gtm.js', 'gtm.start': ts })
+      ├─ flushQueue() ──► pushToDataLayer(queued values)
+      └─ ScriptManager.ensure(containers)
+```
+
+The queue is only flushed after the data layer exists, guaranteeing that pre-init pushes and consent updates execute in request
+order. Re-initialization skips the entire sequence and logs a debug message.
+
+## 3. Consent helpers
+
+The consent module exposes:
+
+- `consent.defaults(state, options?)` – shorthand for `setConsentDefaults` on the shared client.
+- `consent.update(state, options?)` – shorthand for updating consent after defaults are applied.
+- `buildConsentCommand({ command, state, options })` – emits the GTM command tuple used by the data layer. Intended for advanced
+  integrations that push directly without instantiating a client.
+- `consentPresets` & `getConsentPreset(name)` – curated sets of `ConsentState` objects (e.g., `full`, `denied`, `eeaPartial`).
+
+All helpers validate that provided keys map to the known Consent Mode parameters. Unknown keys are rejected at compile time via
+TypeScript interfaces.
+
+## 4. Noscript helper
+
+`createNoscriptMarkup(containers, options?)` mirrors the loader behavior for non-JavaScript scenarios:
+
+- Accepts a single container ID or array. When an array is provided, multiple iframe tags are emitted in order.
+- Applies `DEFAULT_NOSCRIPT_IFRAME_ATTRIBUTES` unless overridden via `options.iframeAttributes`.
+- Merges container-level `queryParams` with global `defaultQueryParams`, matching the loader semantics.
+- Escapes attribute values to prevent HTML injection when server-rendering the returned string.
+
+This helper is pure: it does not touch the DOM and can be invoked at build time or request time.
+
+## 5. Non-goals for the core API
+
+- No automatic pageview or event semantics—framework adapters and examples own that behavior.
+- No persistence or cookie management beyond what GTM performs.
+- No implicit global singletons: each `createGtmClient` call returns an isolated manager (scripts dedupe via DOM markers).
+
+## 6. Versioning commitment
+
+- Breaking API changes require a new sign-off revision and a semantic major release.
+- Additive, backward-compatible changes (e.g., new optional fields) require documentation updates and DX review.
+- Internal refactors must preserve the behaviors enumerated in this document (idempotent init, queue ordering, consent mapping).
+
+## 7. Open items before final sign-off
+
+- Confirm logger defaults with DX (should we expose structured payload typing?).
+- Validate whether the consent presets list needs expansion prior to beta.
+- Produce a companion architecture diagram under `docs/design/architecture/` illustrating the loader + data layer interactions.

--- a/docs/governance/OWNERS.md
+++ b/docs/governance/OWNERS.md
@@ -1,0 +1,19 @@
+# Ownership matrix
+
+This matrix establishes the accountable owners for the React GTM Kit project. Update it whenever maintainers rotate or coverage
+areas change.
+
+| Area | Responsibilities | Primary | Backup |
+| --- | --- | --- | --- |
+| Core library (`@react-gtm-kit/core`) | API stability, data layer lifecycle, consent handling, build tooling | Casey Rivera | Morgan Patel |
+| React adapters | Provider + HOC ergonomics, StrictMode verification, adapter docs | Morgan Patel | Casey Rivera |
+| Next.js helpers | App Router integration, CSP threading, noscript bridge | Alex Nguyen | Casey Rivera |
+| Documentation | Task-based docs, API reference, examples alignment | Priya Shah | Alex Nguyen |
+| Examples & E2E | Sample apps, Playwright suites, CI smoke coverage | Jordan Lee | Priya Shah |
+| Governance & releases | Semantic-release, support policy, compliance artifacts | Priya Shah | Morgan Patel |
+
+**Escalation path:** Core engineering → DX (documentation) → Product/Compliance.
+
+**Slack channels:** `#react-gtm-kit-core` (engineering), `#react-gtm-kit-launch` (cross-functional).
+
+_Last updated: 2025-11-06_


### PR DESCRIPTION
## Summary
- draft the core API sign-off document describing exports, lifecycle, and consent/noscript helpers
- log the pending M0 API freeze decision and capture ownership matrix for stakeholders
- update the task tracker to reflect the new documentation and review status

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690bde8ffa748323ae6c898956c40455