### PR TITLE
Prepare GTM-Kit package for npm release

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -10,18 +10,28 @@ module.exports = {
         changelogFile: 'CHANGELOG.md'
       }
     ],
+    // Root package - don't publish (private monorepo root)
     [
       '@semantic-release/npm',
       {
         npmPublish: false
       }
     ],
+    // Convert workspace:* dependencies to actual versions before publishing
+    [
+      '@semantic-release/exec',
+      {
+        prepareCmd: 'node scripts/prepare-publish.mjs'
+      }
+    ],
+    // Core package - must be published first (others depend on it)
     [
       '@semantic-release/npm',
       {
         pkgRoot: 'packages/core'
       }
     ],
+    // React packages
     [
       '@semantic-release/npm',
       {
@@ -34,10 +44,50 @@ module.exports = {
         pkgRoot: 'packages/react-legacy'
       }
     ],
+    // Meta-framework packages
     [
       '@semantic-release/npm',
       {
         pkgRoot: 'packages/next'
+      }
+    ],
+    [
+      '@semantic-release/npm',
+      {
+        pkgRoot: 'packages/remix'
+      }
+    ],
+    // Vue ecosystem
+    [
+      '@semantic-release/npm',
+      {
+        pkgRoot: 'packages/vue'
+      }
+    ],
+    [
+      '@semantic-release/npm',
+      {
+        pkgRoot: 'packages/nuxt'
+      }
+    ],
+    // Other frameworks
+    [
+      '@semantic-release/npm',
+      {
+        pkgRoot: 'packages/svelte'
+      }
+    ],
+    [
+      '@semantic-release/npm',
+      {
+        pkgRoot: 'packages/solid'
+      }
+    ],
+    // CLI tool
+    [
+      '@semantic-release/npm',
+      {
+        pkgRoot: 'packages/cli'
       }
     ],
     [

--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ bun add @jwiedeman/gtm-kit @jwiedeman/gtm-kit-react
 
 </details>
 
+<details>
+<summary><strong>Installing from GitHub (for pre-release or bleeding edge)</strong></summary>
+
+If you want to test unreleased features or use a specific branch/commit:
+
+```bash
+# Latest from main branch
+npm install github:jwiedeman/GTM-Kit
+
+# Specific version tag
+npm install github:jwiedeman/GTM-Kit#v0.1.0
+
+# Specific commit
+npm install github:jwiedeman/GTM-Kit#abc1234
+```
+
+**Note:** Framework packages (react, vue, etc.) are bundled in the monorepo. For GitHub installs, import from the packages directory or use the npm-published packages for the best experience.
+
+</details>
+
 ---
 
 ## Quick Start (5 minutes)

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@playwright/test": "^1.48.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^12.0.0",
+    "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^10.1.0",
     "@semantic-release/npm": "^12.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@semantic-release/commit-analyzer':
         specifier: ^12.0.0
         version: 12.0.0(semantic-release@23.1.1)
+      '@semantic-release/exec':
+        specifier: ^6.0.3
+        version: 6.0.3(semantic-release@23.1.1)
       '@semantic-release/git':
         specifier: ^10.0.1
         version: 10.0.1(semantic-release@23.1.1)
@@ -5517,6 +5520,23 @@ packages:
   /@semantic-release/error@4.0.0:
     resolution: {integrity: sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==}
     engines: {node: '>=18'}
+    dev: true
+
+  /@semantic-release/exec@6.0.3(semantic-release@23.1.1):
+    resolution: {integrity: sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==}
+    engines: {node: '>=14.17'}
+    peerDependencies:
+      semantic-release: '>=18.0.0'
+    dependencies:
+      '@semantic-release/error': 3.0.0
+      aggregate-error: 3.1.0
+      debug: 4.4.3
+      execa: 5.1.1
+      lodash: 4.17.21
+      parse-json: 5.2.0
+      semantic-release: 23.1.1(typescript@5.4.5)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@semantic-release/git@10.0.1(semantic-release@23.1.1):

--- a/scripts/prepare-publish.mjs
+++ b/scripts/prepare-publish.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Prepares packages for npm publishing by converting workspace:* dependencies
+ * to actual version numbers.
+ *
+ * This script is run as part of the semantic-release prepare phase.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+// Packages that have workspace dependencies
+const packagesWithDeps = ['react-modern', 'react-legacy', 'next', 'remix', 'vue', 'nuxt', 'svelte', 'solid'];
+
+// Map of workspace package names to their directories
+const packageMap = {
+  '@jwiedeman/gtm-kit': 'core',
+  '@jwiedeman/gtm-kit-vue': 'vue'
+};
+
+function getPackageVersion(packageDir) {
+  const pkgPath = join(rootDir, 'packages', packageDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  return pkg.version;
+}
+
+function updatePackageDeps(packageDir) {
+  const pkgPath = join(rootDir, 'packages', packageDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  let modified = false;
+
+  if (pkg.dependencies) {
+    for (const [depName, depVersion] of Object.entries(pkg.dependencies)) {
+      if (depVersion === 'workspace:*') {
+        const depDir = packageMap[depName];
+        if (depDir) {
+          const actualVersion = getPackageVersion(depDir);
+          pkg.dependencies[depName] = `^${actualVersion}`;
+          console.log(`  ${depName}: workspace:* -> ^${actualVersion}`);
+          modified = true;
+        }
+      }
+    }
+  }
+
+  if (modified) {
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  }
+
+  return modified;
+}
+
+console.log('Preparing packages for npm publish...\n');
+
+for (const packageDir of packagesWithDeps) {
+  console.log(`Processing packages/${packageDir}:`);
+  const modified = updatePackageDeps(packageDir);
+  if (!modified) {
+    console.log('  No workspace:* dependencies found');
+  }
+  console.log('');
+}
+
+console.log('Done!');


### PR DESCRIPTION
- Update .releaserc.cjs to publish all 10 packages (core, react-modern, react-legacy, next, remix, vue, nuxt, svelte, solid, cli)
- Add prepare-publish.mjs script to convert workspace:* dependencies to actual version numbers before npm publish
- Add @semantic-release/exec to run prepare script during release
- Update README with GitHub install instructions for pre-release testing