### PR TITLE
fix: remove explicit pnpm version from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8.15.4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8.15.4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
           fetch-depth: 0
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -53,8 +51,6 @@ jobs:
           ref: ${{ github.event.inputs.release_branch || github.ref }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
pnpm/action-setup@v4 now reads version from packageManager field in package.json, and fails if version is also specified in the workflow.