### PR TITLE
fix: update runtime deps check for new package names and add build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install
+      - name: Build packages
+        if: ${{ matrix.task == 'test' || matrix.task == 'typecheck' || matrix.task == 'verify:lightweight' }}
+        run: pnpm run build
       - name: Run ${{ matrix.task }}
         run: pnpm run ${{ matrix.task }}
       - name: Upload coverage to Codecov

--- a/scripts/check-runtime-deps.mjs
+++ b/scripts/check-runtime-deps.mjs
@@ -6,24 +6,54 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 
 const checks = [
   {
-    name: '@react-gtm-kit/core',
+    name: '@jwiedeman/gtm-kit',
     manifest: 'packages/core/package.json',
     allow: []
   },
   {
-    name: '@react-gtm-kit/react-modern',
+    name: '@jwiedeman/gtm-kit-react',
     manifest: 'packages/react-modern/package.json',
-    allow: ['@react-gtm-kit/core']
+    allow: ['@jwiedeman/gtm-kit']
   },
   {
-    name: '@react-gtm-kit/react-legacy',
+    name: '@jwiedeman/gtm-kit-react-legacy',
     manifest: 'packages/react-legacy/package.json',
-    allow: ['@react-gtm-kit/core']
+    allow: ['@jwiedeman/gtm-kit']
   },
   {
-    name: '@react-gtm-kit/next',
+    name: '@jwiedeman/gtm-kit-next',
     manifest: 'packages/next/package.json',
-    allow: ['@react-gtm-kit/core']
+    allow: ['@jwiedeman/gtm-kit']
+  },
+  {
+    name: '@jwiedeman/gtm-kit-remix',
+    manifest: 'packages/remix/package.json',
+    allow: ['@jwiedeman/gtm-kit']
+  },
+  {
+    name: '@jwiedeman/gtm-kit-vue',
+    manifest: 'packages/vue/package.json',
+    allow: ['@jwiedeman/gtm-kit']
+  },
+  {
+    name: '@jwiedeman/gtm-kit-nuxt',
+    manifest: 'packages/nuxt/package.json',
+    allow: ['@jwiedeman/gtm-kit', '@jwiedeman/gtm-kit-vue']
+  },
+  {
+    name: '@jwiedeman/gtm-kit-svelte',
+    manifest: 'packages/svelte/package.json',
+    allow: ['@jwiedeman/gtm-kit']
+  },
+  {
+    name: '@jwiedeman/gtm-kit-solid',
+    manifest: 'packages/solid/package.json',
+    allow: ['@jwiedeman/gtm-kit']
+  },
+  {
+    name: '@jwiedeman/gtm-kit-cli',
+    manifest: 'packages/cli/package.json',
+    allow: []
   }
 ];
 


### PR DESCRIPTION
- Update check-runtime-deps.mjs to use @jwiedeman scoped package names
- Add all packages to the runtime dependency check
- Add build step in CI before test/typecheck/verify tasks since packages depend on each other and need built outputs