### PR TITLE
fix(next): add 'use client' banner to built output

### DIFF
--- a/packages/next/tsup.config.ts
+++ b/packages/next/tsup.config.ts
@@ -4,5 +4,9 @@ import baseConfig from '../../config/tsup.base';
 export default defineConfig((options) => ({
   ...baseConfig,
   clean: !options.watch,
-  entry: ['src/index.ts']
+  entry: ['src/index.ts'],
+  // Add 'use client' directive for Next.js App Router compatibility
+  banner: {
+    js: `'use client';`
+  }
 }));


### PR DESCRIPTION
The Next.js package uses React hooks and next/navigation which require the 'use client' directive. tsup was stripping it during bundling, causing build failures when the package is imported from Server Components.