### PR TITLE
Support granular consent states in manager

### DIFF
--- a/docs/concepts/consent-lifecycle.md
+++ b/docs/concepts/consent-lifecycle.md
@@ -3,17 +3,72 @@
 Consent Mode v2 support is built into the core package. Use this guide to align your
 CMP integration with the kit's APIs.
 
-## Consent states
+## Consent categories
 
-Google tracks four keys:
+Google Consent Mode v2 tracks four categories:
 
-- `ad_storage`
-- `analytics_storage`
-- `ad_user_data`
-- `ad_personalization`
+| Category             | Purpose                                | When to grant                              |
+| -------------------- | -------------------------------------- | ------------------------------------------ |
+| `ad_storage`         | Stores advertising cookies/identifiers | User accepts advertising/marketing cookies |
+| `analytics_storage`  | Stores analytics cookies               | User accepts analytics/statistics cookies  |
+| `ad_user_data`       | Sends user data to Google for ads      | User consents to ad data sharing           |
+| `ad_personalization` | Enables personalized advertising       | User consents to personalized ads          |
 
-Each key accepts `granted` or `denied`. React GTM Kit defaults to `denied` until you
-explicitly update consent.
+Each category accepts `'granted'` or `'denied'`. GTM Kit defaults all categories to `denied`
+until you explicitly update them.
+
+## Granular consent updates
+
+GTM Kit supports **granular consent** - you can update individual categories independently
+without affecting others. This is critical for CMPs that let users make selective choices.
+
+### Update patterns
+
+```ts
+// All granted (user accepts everything)
+client.updateConsent({
+  ad_storage: 'granted',
+  analytics_storage: 'granted',
+  ad_user_data: 'granted',
+  ad_personalization: 'granted'
+});
+
+// All denied (user rejects everything)
+client.updateConsent({
+  ad_storage: 'denied',
+  analytics_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied'
+});
+
+// Mixed consent (user accepts analytics only)
+client.updateConsent({
+  ad_storage: 'denied',
+  analytics_storage: 'granted',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied'
+});
+
+// Partial update (only update specific categories)
+// Other categories remain unchanged
+client.updateConsent({ analytics_storage: 'granted' });
+
+// Multiple partial updates over time
+client.updateConsent({ analytics_storage: 'granted' });
+// ...later, user changes ad preferences...
+client.updateConsent({ ad_storage: 'granted', ad_user_data: 'granted' });
+```
+
+### Why partial updates matter
+
+Many CMPs provide granular consent controls where users can:
+
+- Accept analytics but reject advertising
+- Change individual preferences over time
+- Have different consent states per category
+
+GTM Kit's `Partial<Record<ConsentKey, ConsentDecision>>` type ensures you only need to
+pass the categories that changed. Unspecified categories retain their previous state.
 
 ## Event timeline
 
@@ -29,11 +84,42 @@ explicitly update consent.
    value and feed it back into `setConsentDefaults` on the next page load so GTM stays
    consistent.
 
+## Built-in presets
+
+GTM Kit provides convenience presets for common scenarios:
+
+| Preset                         | `ad_storage` | `analytics_storage` | `ad_user_data` | `ad_personalization` |
+| ------------------------------ | ------------ | ------------------- | -------------- | -------------------- |
+| `consentPresets.eeaDefault`    | denied       | denied              | denied         | denied               |
+| `consentPresets.allGranted`    | granted      | granted             | granted        | granted              |
+| `consentPresets.analyticsOnly` | denied       | granted             | denied         | denied               |
+
+```ts
+import { consentPresets } from '@react-gtm-kit/core';
+
+// Use preset for defaults
+client.setConsentDefaults(consentPresets.eeaDefault, { region: ['EEA'] });
+
+// Or use preset for updates
+client.updateConsent(consentPresets.allGranted);
+```
+
 ## Implementation checklist
 
-- Map every CMP status (e.g., `accepted`, `rejected`, `partial`) to a corresponding
-  Consent Mode state.
-- Keep consent updates on the main thread; GTM expects synchronous updates before tags
-  fire.
-- Use the React adapters' consent helpers to avoid duplicating logic when working in React.
-- Document your mapping strategy so audits can confirm the data flow.
+- [ ] Map every CMP status (e.g., `accepted`, `rejected`, `partial`) to a corresponding
+      Consent Mode state
+- [ ] Support granular updates - don't assume all-or-nothing consent
+- [ ] Keep consent updates on the main thread; GTM expects synchronous updates before tags
+      fire
+- [ ] Use the framework adapters' consent helpers to avoid duplicating logic
+- [ ] Test all consent scenarios: all granted, all denied, and mixed states
+- [ ] Document your CMP-to-Consent-Mode mapping strategy for audits
+
+### CMP mapping example
+
+| CMP Choice       | GTM Kit update                                       |
+| ---------------- | ---------------------------------------------------- |
+| Accept All       | `updateConsent(consentPresets.allGranted)`           |
+| Reject All       | `updateConsent(consentPresets.eeaDefault)`           |
+| Analytics Only   | `updateConsent(consentPresets.analyticsOnly)`        |
+| Custom Selection | Map each CMP category to its Consent Mode equivalent |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -48,16 +48,16 @@ pushEvent(gtm, 'purchase', { value: 49.99, currency: 'USD' });
 
 ## Features
 
-| Feature | Description |
-|---------|-------------|
-| **Zero Dependencies** | No bloat - just what you need |
-| **3.7KB Gzipped** | Minimal impact on bundle size |
-| **SSR-Safe** | Works with server-side rendering |
-| **Consent Mode v2** | Built-in GDPR compliance support |
-| **Multiple Containers** | Load multiple GTM containers |
-| **Custom DataLayer** | Use custom dataLayer names |
-| **CSP Support** | Content Security Policy nonce support |
-| **TypeScript** | Full type definitions included |
+| Feature                 | Description                           |
+| ----------------------- | ------------------------------------- |
+| **Zero Dependencies**   | No bloat - just what you need         |
+| **3.7KB Gzipped**       | Minimal impact on bundle size         |
+| **SSR-Safe**            | Works with server-side rendering      |
+| **Consent Mode v2**     | Built-in GDPR compliance support      |
+| **Multiple Containers** | Load multiple GTM containers          |
+| **Custom DataLayer**    | Use custom dataLayer names            |
+| **CSP Support**         | Content Security Policy nonce support |
+| **TypeScript**          | Full type definitions included        |
 
 ---
 
@@ -69,22 +69,22 @@ Creates a new GTM client instance.
 
 ```ts
 const client = createGtmClient({
-  containers: 'GTM-XXXXXX',           // Required: ID or array of IDs
-  dataLayerName: 'dataLayer',          // Optional: custom name
+  containers: 'GTM-XXXXXX', // Required: ID or array of IDs
+  dataLayerName: 'dataLayer', // Optional: custom name
   host: 'https://www.googletagmanager.com', // Optional: custom host
-  scriptAttributes: { nonce: '...' }   // Optional: for CSP
+  scriptAttributes: { nonce: '...' } // Optional: for CSP
 });
 ```
 
 ### Client Methods
 
 ```ts
-client.init();                          // Load GTM scripts
-client.push({ event: 'custom' });       // Push to dataLayer
-client.setConsentDefaults(state);       // Set consent (before init)
-client.updateConsent(state);            // Update consent (after action)
-client.teardown();                      // Cleanup (for tests)
-await client.whenReady();               // Wait for scripts to load
+client.init(); // Load GTM scripts
+client.push({ event: 'custom' }); // Push to dataLayer
+client.setConsentDefaults(state); // Set consent (before init)
+client.updateConsent(state); // Update consent (after action)
+client.teardown(); // Cleanup (for tests)
+await client.whenReady(); // Wait for scripts to load
 ```
 
 ### Event Helpers
@@ -98,7 +98,7 @@ pushEvent(client, 'button_click', { button_id: 'cta-main' });
 // Ecommerce event (GA4 format)
 pushEcommerce(client, 'purchase', {
   transaction_id: 'T-12345',
-  value: 120.00,
+  value: 120.0,
   currency: 'USD',
   items: [{ item_id: 'SKU-001', item_name: 'Blue T-Shirt', price: 40, quantity: 3 }]
 });
@@ -122,10 +122,32 @@ client.updateConsent({
 });
 ```
 
+**Granular Consent** - Update individual categories without affecting others:
+
+```ts
+// All granted
+client.updateConsent(consentPresets.allGranted);
+
+// All denied
+client.updateConsent(consentPresets.eeaDefault);
+
+// Mixed: analytics only, no ads
+client.updateConsent(consentPresets.analyticsOnly);
+
+// Partial update: only update specific categories
+client.updateConsent({ analytics_storage: 'granted' });
+
+// Update multiple specific categories
+client.updateConsent({ ad_storage: 'granted', ad_user_data: 'granted' });
+```
+
 **Built-in Presets:**
-- `consentPresets.eeaDefault` - All denied (GDPR default)
-- `consentPresets.allGranted` - All granted
-- `consentPresets.analyticsOnly` - Analytics only, no ads
+
+| Preset          | ad_storage | analytics_storage | ad_user_data | ad_personalization |
+| --------------- | ---------- | ----------------- | ------------ | ------------------ |
+| `eeaDefault`    | denied     | denied            | denied       | denied             |
+| `allGranted`    | granted    | granted           | granted      | granted            |
+| `analyticsOnly` | denied     | granted           | denied       | denied             |
 
 ---
 
@@ -133,10 +155,7 @@ client.updateConsent({
 
 ```ts
 const client = createGtmClient({
-  containers: [
-    { id: 'GTM-MAIN' },
-    { id: 'GTM-ADS', queryParams: { gtm_auth: 'abc', gtm_preview: 'env-1' } }
-  ]
+  containers: [{ id: 'GTM-MAIN' }, { id: 'GTM-ADS', queryParams: { gtm_auth: 'abc', gtm_preview: 'env-1' } }]
 });
 ```
 
@@ -158,13 +177,13 @@ const noscriptHtml = generateNoscriptHtml('GTM-XXXXXX');
 
 While `@react-gtm-kit/core` works standalone, we provide framework-specific adapters for better ergonomics:
 
-| Framework | Package | Install |
-|-----------|---------|---------|
+| Framework     | Package                       | Install                                                       |
+| ------------- | ----------------------------- | ------------------------------------------------------------- |
 | React (hooks) | `@react-gtm-kit/react-modern` | `npm install @react-gtm-kit/core @react-gtm-kit/react-modern` |
 | React (class) | `@react-gtm-kit/react-legacy` | `npm install @react-gtm-kit/core @react-gtm-kit/react-legacy` |
-| Vue 3 | `@react-gtm-kit/vue` | `npm install @react-gtm-kit/core @react-gtm-kit/vue` |
-| Nuxt 3 | `@react-gtm-kit/nuxt` | `npm install @react-gtm-kit/core @react-gtm-kit/nuxt` |
-| Next.js | `@react-gtm-kit/next` | `npm install @react-gtm-kit/core @react-gtm-kit/next` |
+| Vue 3         | `@react-gtm-kit/vue`          | `npm install @react-gtm-kit/core @react-gtm-kit/vue`          |
+| Nuxt 3        | `@react-gtm-kit/nuxt`         | `npm install @react-gtm-kit/core @react-gtm-kit/nuxt`         |
+| Next.js       | `@react-gtm-kit/next`         | `npm install @react-gtm-kit/core @react-gtm-kit/next`         |
 
 ---
 

--- a/packages/core/src/consent.ts
+++ b/packages/core/src/consent.ts
@@ -4,15 +4,49 @@ const CONSENT_COMMAND = 'consent' as const;
 const CONSENT_DEFAULT = 'default' as const;
 const CONSENT_UPDATE = 'update' as const;
 
-const CONSENT_KEYS = [
-  'ad_storage',
-  'analytics_storage',
-  'ad_user_data',
-  'ad_personalization'
-] as const;
+/**
+ * The four consent categories tracked by Google Consent Mode v2.
+ */
+const CONSENT_KEYS = ['ad_storage', 'analytics_storage', 'ad_user_data', 'ad_personalization'] as const;
 
+/**
+ * A consent category key: 'ad_storage' | 'analytics_storage' | 'ad_user_data' | 'ad_personalization'
+ */
 export type ConsentKey = (typeof CONSENT_KEYS)[number];
+
+/**
+ * A consent decision: 'granted' or 'denied'
+ */
 export type ConsentDecision = 'granted' | 'denied';
+
+/**
+ * Consent state object for one or more categories.
+ *
+ * This is a **partial** record - you only need to specify the categories you want to set.
+ * Unspecified categories retain their previous state when using `updateConsent()`.
+ *
+ * @example
+ * ```ts
+ * // All four categories
+ * const fullState: ConsentState = {
+ *   ad_storage: 'granted',
+ *   analytics_storage: 'granted',
+ *   ad_user_data: 'granted',
+ *   ad_personalization: 'granted'
+ * };
+ *
+ * // Single category (partial update)
+ * const partialState: ConsentState = {
+ *   analytics_storage: 'granted'
+ * };
+ *
+ * // Multiple specific categories
+ * const mixedState: ConsentState = {
+ *   analytics_storage: 'granted',
+ *   ad_storage: 'denied'
+ * };
+ * ```
+ */
 export type ConsentState = Partial<Record<ConsentKey, ConsentDecision>>;
 
 export interface ConsentRegionOptions {
@@ -38,11 +72,9 @@ export type ConsentCommandValue =
   | [typeof CONSENT_COMMAND, ConsentCommand, ConsentState]
   | [typeof CONSENT_COMMAND, ConsentCommand, ConsentState, Record<string, unknown>];
 
-const isConsentKey = (value: string): value is ConsentKey =>
-  (CONSENT_KEYS as readonly string[]).includes(value);
+const isConsentKey = (value: string): value is ConsentKey => (CONSENT_KEYS as readonly string[]).includes(value);
 
-const isConsentDecision = (value: unknown): value is ConsentDecision =>
-  value === 'granted' || value === 'denied';
+const isConsentDecision = (value: unknown): value is ConsentDecision => value === 'granted' || value === 'denied';
 
 const assertValidRegions = (regions: readonly string[]) => {
   if (!Array.isArray(regions)) {
@@ -109,11 +141,7 @@ const normalizeOptions = (options?: ConsentRegionOptions): Record<string, unknow
   return Object.keys(payload).length ? payload : undefined;
 };
 
-export const buildConsentCommand = ({
-  command,
-  state,
-  options
-}: ConsentCommandInput): ConsentCommandValue => {
+export const buildConsentCommand = ({ command, state, options }: ConsentCommandInput): ConsentCommandValue => {
   if (command !== CONSENT_DEFAULT && command !== CONSENT_UPDATE) {
     throw new Error(`Unsupported consent command: ${command}`);
   }
@@ -131,15 +159,11 @@ export const buildConsentCommand = ({
 export const createConsentCommandValue = (input: ConsentCommandInput): DataLayerValue =>
   buildConsentCommand(input) as unknown as DataLayerValue;
 
-export const createConsentDefaultsCommand = (
-  state: ConsentState,
-  options?: ConsentRegionOptions
-): DataLayerValue => createConsentCommandValue({ command: CONSENT_DEFAULT, state, options });
+export const createConsentDefaultsCommand = (state: ConsentState, options?: ConsentRegionOptions): DataLayerValue =>
+  createConsentCommandValue({ command: CONSENT_DEFAULT, state, options });
 
-export const createConsentUpdateCommand = (
-  state: ConsentState,
-  options?: ConsentRegionOptions
-): DataLayerValue => createConsentCommandValue({ command: CONSENT_UPDATE, state, options });
+export const createConsentUpdateCommand = (state: ConsentState, options?: ConsentRegionOptions): DataLayerValue =>
+  createConsentCommandValue({ command: CONSENT_UPDATE, state, options });
 
 export const consent = {
   buildConsentCommand,

--- a/packages/core/src/consent/presets.ts
+++ b/packages/core/src/consent/presets.ts
@@ -1,9 +1,44 @@
 import type { ConsentState } from '../consent';
 
+/**
+ * Pre-configured consent state presets for common scenarios.
+ *
+ * These presets cover the most common consent patterns:
+ * - `eeaDefault`: All denied (GDPR compliant default)
+ * - `allGranted`: All granted (user accepts everything)
+ * - `analyticsOnly`: Mixed state (analytics only, no ads)
+ *
+ * For custom combinations, pass a partial `ConsentState` object to `updateConsent()`.
+ * You only need to specify the categories you want to update.
+ *
+ * @example
+ * ```ts
+ * // Use a preset
+ * client.updateConsent(consentPresets.allGranted);
+ *
+ * // Or create a custom state
+ * client.updateConsent({
+ *   analytics_storage: 'granted',
+ *   ad_storage: 'denied'
+ * });
+ *
+ * // Partial updates (only update specific categories)
+ * client.updateConsent({ analytics_storage: 'granted' });
+ * ```
+ */
 export const consentPresets = {
   /**
-   * Baseline preset recommended by Google for users in regions that require explicit opt-in
-   * before enabling advertising or analytics tags.
+   * All categories denied - GDPR/EEA compliant default.
+   *
+   * Use as the initial state for regions requiring explicit opt-in consent.
+   * Tags will be blocked until the user grants specific permissions.
+   *
+   * | Category | State |
+   * |----------|-------|
+   * | ad_storage | denied |
+   * | analytics_storage | denied |
+   * | ad_user_data | denied |
+   * | ad_personalization | denied |
    */
   eeaDefault: Object.freeze({
     ad_storage: 'denied',
@@ -11,8 +46,18 @@ export const consentPresets = {
     ad_user_data: 'denied',
     ad_personalization: 'denied'
   } satisfies ConsentState),
+
   /**
-   * Convenience preset granting all consent categories.
+   * All categories granted - user accepts all tracking.
+   *
+   * Use when the user clicks "Accept All" or in regions where consent is implied.
+   *
+   * | Category | State |
+   * |----------|-------|
+   * | ad_storage | granted |
+   * | analytics_storage | granted |
+   * | ad_user_data | granted |
+   * | ad_personalization | granted |
    */
   allGranted: Object.freeze({
     ad_storage: 'granted',
@@ -20,8 +65,19 @@ export const consentPresets = {
     ad_user_data: 'granted',
     ad_personalization: 'granted'
   } satisfies ConsentState),
+
   /**
-   * Preset to allow analytics measurement while preventing ad personalisation and storage.
+   * Analytics allowed, advertising denied - mixed consent state.
+   *
+   * Use when the user accepts analytics/statistics but rejects advertising cookies.
+   * This is a common "essential + analytics" consent pattern.
+   *
+   * | Category | State |
+   * |----------|-------|
+   * | ad_storage | denied |
+   * | analytics_storage | granted |
+   * | ad_user_data | denied |
+   * | ad_personalization | denied |
    */
   analyticsOnly: Object.freeze({
     ad_storage: 'denied',

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -78,11 +78,7 @@ import { pushEvent } from '@react-gtm-kit/core';
 
 // In any client component
 function BuyButton({ client }) {
-  return (
-    <button onClick={() => pushEvent(client, 'purchase', { value: 49.99 })}>
-      Buy Now
-    </button>
-  );
+  return <button onClick={() => pushEvent(client, 'purchase', { value: 49.99 })}>Buy Now</button>;
 }
 ```
 
@@ -90,14 +86,14 @@ function BuyButton({ client }) {
 
 ## Features
 
-| Feature | Description |
-|---------|-------------|
-| **Server Components** | `GtmHeadScript` and `GtmNoScript` are server components |
-| **App Router** | Built for Next.js 13+ App Router |
-| **Auto Page Tracking** | `useTrackPageViews` hook for route changes |
-| **CSP Support** | Nonce support for Content Security Policy |
-| **TypeScript** | Full type definitions included |
-| **Lightweight** | Only what you need for Next.js |
+| Feature                | Description                                             |
+| ---------------------- | ------------------------------------------------------- |
+| **Server Components**  | `GtmHeadScript` and `GtmNoScript` are server components |
+| **App Router**         | Built for Next.js 13+ App Router                        |
+| **Auto Page Tracking** | `useTrackPageViews` hook for route changes              |
+| **CSP Support**        | Nonce support for Content Security Policy               |
+| **TypeScript**         | Full type definitions included                          |
+| **Lightweight**        | Only what you need for Next.js                          |
 
 ---
 
@@ -113,7 +109,7 @@ import { GtmHeadScript } from '@react-gtm-kit/next';
 <GtmHeadScript
   containers="GTM-XXXXXX"
   scriptAttributes={{ nonce: 'your-csp-nonce' }} // Optional
-/>
+/>;
 ```
 
 ### `<GtmNoScript />`
@@ -123,7 +119,7 @@ Renders the noscript fallback iframe. Place at the start of `<body>`.
 ```tsx
 import { GtmNoScript } from '@react-gtm-kit/next';
 
-<GtmNoScript containers="GTM-XXXXXX" />
+<GtmNoScript containers="GTM-XXXXXX" />;
 ```
 
 ---
@@ -205,11 +201,7 @@ import { useGtmClient } from '../providers/gtm';
 export function BuyButton() {
   const client = useGtmClient();
 
-  return (
-    <button onClick={() => pushEvent(client, 'purchase', { value: 49.99 })}>
-      Buy Now
-    </button>
-  );
+  return <button onClick={() => pushEvent(client, 'purchase', { value: 49.99 })}>Buy Now</button>;
 }
 ```
 
@@ -242,19 +234,41 @@ export { client };
 // app/components/CookieBanner.tsx
 'use client';
 import { client } from '../providers/gtm';
+import { consentPresets } from '@react-gtm-kit/core';
 
 export function CookieBanner() {
-  const acceptAll = () => {
-    client.updateConsent({
-      ad_storage: 'granted',
-      analytics_storage: 'granted',
-      ad_user_data: 'granted',
-      ad_personalization: 'granted'
-    });
-  };
+  // Accept all tracking
+  const acceptAll = () => client.updateConsent(consentPresets.allGranted);
 
-  return <button onClick={acceptAll}>Accept Cookies</button>;
+  // Reject all tracking
+  const rejectAll = () => client.updateConsent(consentPresets.eeaDefault);
+
+  // Analytics only (mixed consent)
+  const analyticsOnly = () => client.updateConsent(consentPresets.analyticsOnly);
+
+  // Partial update - only change specific categories
+  const customChoice = () =>
+    client.updateConsent({
+      analytics_storage: 'granted',
+      ad_storage: 'denied'
+    });
+
+  return (
+    <div>
+      <button onClick={acceptAll}>Accept All</button>
+      <button onClick={rejectAll}>Reject All</button>
+      <button onClick={analyticsOnly}>Analytics Only</button>
+    </div>
+  );
 }
+```
+
+**Granular Updates** - Update individual categories without affecting others:
+
+```tsx
+// User later changes ad preferences from settings page
+client.updateConsent({ ad_storage: 'granted', ad_user_data: 'granted' });
+// analytics_storage and ad_personalization remain unchanged
 ```
 
 ---
@@ -274,10 +288,7 @@ export default function RootLayout({ children }) {
   return (
     <html>
       <head>
-        <GtmHeadScript
-          containers="GTM-XXXXXX"
-          scriptAttributes={{ nonce }}
-        />
+        <GtmHeadScript containers="GTM-XXXXXX" scriptAttributes={{ nonce }} />
       </head>
       <body>
         <GtmNoScript containers="GTM-XXXXXX" />
@@ -294,10 +305,7 @@ export default function RootLayout({ children }) {
 
 ```tsx
 <GtmHeadScript
-  containers={[
-    { id: 'GTM-MAIN' },
-    { id: 'GTM-ADS', queryParams: { gtm_auth: 'abc', gtm_preview: 'env-1' } }
-  ]}
+  containers={[{ id: 'GTM-MAIN' }, { id: 'GTM-ADS', queryParams: { gtm_auth: 'abc', gtm_preview: 'env-1' } }]}
 />
 ```
 

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -61,14 +61,14 @@ push({ event: 'page_view' });
 
 ## Features
 
-| Feature | Description |
-|---------|-------------|
-| **Native Nuxt Module** | Built specifically for Nuxt 3 |
-| **Auto Page Tracking** | Tracks route changes automatically |
-| **SSR Support** | Server-side rendering compatible |
-| **Composables** | Uses Vue composables under the hood |
-| **TypeScript** | Full type definitions included |
-| **Consent Mode v2** | Built-in GDPR compliance |
+| Feature                | Description                         |
+| ---------------------- | ----------------------------------- |
+| **Native Nuxt Module** | Built specifically for Nuxt 3       |
+| **Auto Page Tracking** | Tracks route changes automatically  |
+| **SSR Support**        | Server-side rendering compatible    |
+| **Composables**        | Uses Vue composables under the hood |
+| **TypeScript**         | Full type definitions included      |
+| **Consent Mode v2**    | Built-in GDPR compliance            |
 
 ---
 
@@ -185,24 +185,50 @@ export default defineNuxtPlugin((nuxtApp) => {
 <!-- components/CookieBanner.vue -->
 <script setup>
 import { useGtmConsent } from '@react-gtm-kit/vue';
+import { consentPresets } from '@react-gtm-kit/core';
 
 const { updateConsent } = useGtmConsent();
 
-function acceptAll() {
+// Accept all tracking
+const acceptAll = () => updateConsent(consentPresets.allGranted);
+
+// Reject all tracking
+const rejectAll = () => updateConsent(consentPresets.eeaDefault);
+
+// Analytics only (mixed consent)
+const analyticsOnly = () => updateConsent(consentPresets.analyticsOnly);
+
+// Partial update - only change specific categories
+const customChoice = () =>
   updateConsent({
-    ad_storage: 'granted',
     analytics_storage: 'granted',
-    ad_user_data: 'granted',
-    ad_personalization: 'granted'
+    ad_storage: 'denied'
   });
-}
 </script>
 
 <template>
   <div class="cookie-banner">
-    <button @click="acceptAll">Accept Cookies</button>
+    <button @click="acceptAll">Accept All</button>
+    <button @click="rejectAll">Reject All</button>
+    <button @click="analyticsOnly">Analytics Only</button>
   </div>
 </template>
+```
+
+**Granular Updates** - Update individual categories without affecting others:
+
+```vue
+<script setup>
+const { updateConsent } = useGtmConsent();
+
+// User later opts into ads from settings page
+const enableAds = () =>
+  updateConsent({
+    ad_storage: 'granted',
+    ad_user_data: 'granted'
+  });
+// analytics_storage and ad_personalization remain unchanged
+</script>
 ```
 
 ---
@@ -239,10 +265,7 @@ For noscript fallback (SEO), you can add this to your `app.vue`:
 // plugins/gtm.client.ts
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(GtmPlugin, {
-    containers: [
-      { id: 'GTM-MAIN' },
-      { id: 'GTM-ADS', queryParams: { gtm_auth: 'abc', gtm_preview: 'env-1' } }
-    ]
+    containers: [{ id: 'GTM-MAIN' }, { id: 'GTM-ADS', queryParams: { gtm_auth: 'abc', gtm_preview: 'env-1' } }]
   });
 });
 ```

--- a/packages/react-modern/README.md
+++ b/packages/react-modern/README.md
@@ -69,14 +69,14 @@ function BuyButton() {
 
 ## Features
 
-| Feature | Description |
-|---------|-------------|
+| Feature             | Description                               |
+| ------------------- | ----------------------------------------- |
 | **StrictMode-Safe** | No double-fires in React development mode |
-| **Hooks-Based** | Modern React patterns with Context API |
-| **React 16.8+** | Works with any modern React version |
-| **TypeScript** | Full type definitions included |
-| **Consent Mode v2** | Built-in GDPR compliance hooks |
-| **SSR Compatible** | Safe for Next.js, Remix, etc. |
+| **Hooks-Based**     | Modern React patterns with Context API    |
+| **React 16.8+**     | Works with any modern React version       |
+| **TypeScript**      | Full type definitions included            |
+| **Consent Mode v2** | Built-in GDPR compliance hooks            |
+| **SSR Compatible**  | Safe for Next.js, Remix, etc.             |
 
 ---
 
@@ -152,23 +152,46 @@ import { consentPresets } from '@react-gtm-kit/core';
   }}
 >
   <App />
-</GtmProvider>
+</GtmProvider>;
 
 // In your cookie banner
 function CookieBanner() {
   const { updateConsent } = useGtmConsent();
 
-  const acceptAll = () => {
-    updateConsent({
-      ad_storage: 'granted',
-      analytics_storage: 'granted',
-      ad_user_data: 'granted',
-      ad_personalization: 'granted'
-    });
-  };
+  // Accept all tracking
+  const acceptAll = () => updateConsent(consentPresets.allGranted);
 
-  return <button onClick={acceptAll}>Accept All</button>;
+  // Reject all tracking
+  const rejectAll = () => updateConsent(consentPresets.eeaDefault);
+
+  // Analytics only (mixed consent)
+  const analyticsOnly = () => updateConsent(consentPresets.analyticsOnly);
+
+  // Granular: update specific categories
+  const customChoice = () =>
+    updateConsent({
+      analytics_storage: 'granted',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied'
+    });
+
+  return (
+    <div>
+      <button onClick={acceptAll}>Accept All</button>
+      <button onClick={rejectAll}>Reject All</button>
+      <button onClick={analyticsOnly}>Analytics Only</button>
+    </div>
+  );
 }
+```
+
+**Partial Updates** - Only update what changed:
+
+```tsx
+// User later opts into ads from preference center
+updateConsent({ ad_storage: 'granted', ad_user_data: 'granted' });
+// Other categories (analytics_storage, ad_personalization) unchanged
 ```
 
 ---
@@ -178,9 +201,9 @@ function CookieBanner() {
 ```tsx
 <GtmProvider
   config={{
-    containers: 'GTM-XXXXXX',        // Required
-    dataLayerName: 'dataLayer',       // Optional
-    host: 'https://custom.host.com',  // Optional
+    containers: 'GTM-XXXXXX', // Required
+    dataLayerName: 'dataLayer', // Optional
+    host: 'https://custom.host.com', // Optional
     scriptAttributes: { nonce: '...' } // Optional: CSP
   }}
   onBeforeInit={(client) => {

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -40,9 +40,7 @@ import { createApp } from 'vue';
 import { GtmPlugin } from '@react-gtm-kit/vue';
 import App from './App.vue';
 
-createApp(App)
-  .use(GtmPlugin, { containers: 'GTM-XXXXXX' })
-  .mount('#app');
+createApp(App).use(GtmPlugin, { containers: 'GTM-XXXXXX' }).mount('#app');
 ```
 
 ### Step 2: Push Events
@@ -69,14 +67,14 @@ function handleClick() {
 
 ## Features
 
-| Feature | Description |
-|---------|-------------|
-| **Vue 3 Native** | Built for Composition API |
-| **Composables** | Clean, reactive Vue patterns |
-| **TypeScript** | Full type definitions included |
-| **Consent Mode v2** | Built-in GDPR compliance |
-| **SSR Compatible** | Safe for Nuxt and Vite SSR |
-| **Lightweight** | ~4KB gzipped |
+| Feature             | Description                    |
+| ------------------- | ------------------------------ |
+| **Vue 3 Native**    | Built for Composition API      |
+| **Composables**     | Clean, reactive Vue patterns   |
+| **TypeScript**      | Full type definitions included |
+| **Consent Mode v2** | Built-in GDPR compliance       |
+| **SSR Compatible**  | Safe for Nuxt and Vite SSR     |
+| **Lightweight**     | ~4KB gzipped                   |
 
 ---
 
@@ -171,9 +169,9 @@ onMounted(async () => {
 
 ```ts
 app.use(GtmPlugin, {
-  containers: 'GTM-XXXXXX',          // Required
-  dataLayerName: 'dataLayer',         // Optional
-  host: 'https://custom.host.com',    // Optional
+  containers: 'GTM-XXXXXX', // Required
+  dataLayerName: 'dataLayer', // Optional
+  host: 'https://custom.host.com', // Optional
   scriptAttributes: { nonce: '...' }, // Optional: CSP
   onBeforeInit: (client) => {
     // Called before GTM initializes
@@ -261,26 +259,27 @@ createApp(App)
 <!-- CookieBanner.vue -->
 <script setup>
 import { useGtmConsent } from '@react-gtm-kit/vue';
+import { consentPresets } from '@react-gtm-kit/core';
 
 const { updateConsent } = useGtmConsent();
 
-function acceptAll() {
-  updateConsent({
-    ad_storage: 'granted',
-    analytics_storage: 'granted',
-    ad_user_data: 'granted',
-    ad_personalization: 'granted'
-  });
-}
+// Accept all tracking
+const acceptAll = () => updateConsent(consentPresets.allGranted);
 
-function rejectAll() {
+// Reject all tracking
+const rejectAll = () => updateConsent(consentPresets.eeaDefault);
+
+// Analytics only (mixed consent)
+const analyticsOnly = () => updateConsent(consentPresets.analyticsOnly);
+
+// Granular: custom selection
+const customChoice = () =>
   updateConsent({
+    analytics_storage: 'granted',
     ad_storage: 'denied',
-    analytics_storage: 'denied',
     ad_user_data: 'denied',
     ad_personalization: 'denied'
   });
-}
 </script>
 
 <template>
@@ -288,8 +287,27 @@ function rejectAll() {
     <p>We use cookies to improve your experience.</p>
     <button @click="acceptAll">Accept All</button>
     <button @click="rejectAll">Reject All</button>
+    <button @click="analyticsOnly">Analytics Only</button>
   </div>
 </template>
+```
+
+**Partial Updates** - Only update changed categories:
+
+```vue
+<script setup>
+import { useGtmConsent } from '@react-gtm-kit/vue';
+
+const { updateConsent } = useGtmConsent();
+
+// User later opts into ads from preference center
+const enableAds = () =>
+  updateConsent({
+    ad_storage: 'granted',
+    ad_user_data: 'granted'
+  });
+// Other categories (analytics_storage, ad_personalization) remain unchanged
+</script>
 ```
 
 ---


### PR DESCRIPTION
- Add explicit granular consent section to consent-lifecycle.md explaining partial updates and mixed consent states
- Update consent.md how-to guide with examples for all scenarios: all granted, all denied, mixed consent, and partial updates
- Improve core README consent section with granular examples and preset reference table
- Update react-modern, next, vue, and nuxt READMEs with:
  - Accept All / Reject All / Analytics Only buttons
  - Partial update examples
  - consentPresets usage
- Enhance JSDoc comments in consent.ts and presets.ts with detailed examples showing partial ConsentState usage
- Update cmp-integration.md with granular mapping examples

This ensures developers understand that GTM Kit supports:
1. All granted (user accepts everything)
2. All denied (user rejects everything)
3. Mixed/granular consent (some granted, some denied)
4. Partial updates (only update specific categories)