### PR TITLE
fix: add publishConfig access:public to all packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,9 @@
     "setup"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "bin": {
     "gtm-kit": "./dist/cli.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,9 @@
     "dataLayer"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -16,6 +16,9 @@
     "app-router"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -16,6 +16,9 @@
     "module"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/react-legacy/package.json
+++ b/packages/react-legacy/package.json
@@ -15,6 +15,9 @@
     "hoc"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/react-modern/package.json
+++ b/packages/react-modern/package.json
@@ -15,6 +15,9 @@
     "hooks"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -15,6 +15,9 @@
     "routes"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -16,6 +16,9 @@
     "primitives"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -15,6 +15,9 @@
     "stores"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -16,6 +16,9 @@
     "composables"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
Scoped npm packages (@jwiedeman/*) are private by default, which requires a paid npm account. Adding publishConfig with access:public allows publishing these packages to npm for free as public packages.