### PR TITLE
fix: prevent lockfile mismatch after release

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -93,7 +93,7 @@ module.exports = {
     [
       '@semantic-release/git',
       {
-        assets: ['CHANGELOG.md', 'package.json', 'pnpm-lock.yaml', 'packages/*/package.json'],
+        assets: ['CHANGELOG.md', 'package.json', 'pnpm-lock.yaml'],
         message: 'chore(release): ${nextRelease.version}'
       }
     ],

--- a/scripts/prepare-publish.mjs
+++ b/scripts/prepare-publish.mjs
@@ -22,11 +22,16 @@ const packageMap = {
   '@jwiedeman/gtm-kit-vue': 'vue'
 };
 
-function getPackageVersion(packageDir) {
-  const pkgPath = join(rootDir, 'packages', packageDir, 'package.json');
+// Get version from root package.json (already updated by semantic-release)
+// All packages in this monorepo share the same version
+function getReleaseVersion() {
+  const pkgPath = join(rootDir, 'package.json');
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
   return pkg.version;
 }
+
+const releaseVersion = getReleaseVersion();
+console.log(`Release version: ${releaseVersion}\n`);
 
 function updatePackageDeps(packageDir) {
   const pkgPath = join(rootDir, 'packages', packageDir, 'package.json');
@@ -38,9 +43,9 @@ function updatePackageDeps(packageDir) {
       if (depVersion === 'workspace:*') {
         const depDir = packageMap[depName];
         if (depDir) {
-          const actualVersion = getPackageVersion(depDir);
-          pkg.dependencies[depName] = `^${actualVersion}`;
-          console.log(`  ${depName}: workspace:* -> ^${actualVersion}`);
+          // Use the release version from root package.json
+          pkg.dependencies[depName] = `^${releaseVersion}`;
+          console.log(`  ${depName}: workspace:* -> ^${releaseVersion}`);
           modified = true;
         }
       }


### PR DESCRIPTION
Two issues fixed:

1. Don't commit packages/*/package.json in semantic-release. The prepare-publish.mjs script converts workspace:* dependencies to actual versions for npm publishing. These changes were being committed, causing subsequent CI runs to fail because the lockfile still had workspace:* references.

2. Read release version from root package.json. The root package.json is already updated by semantic-release before prepare-publish.mjs runs, so we use that version for all dependencies instead of trying to read from individual package.json files.