### PR TITLE
fix: restore workspace:* dependencies after failed release

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jwiedeman/gtm-kit": "^0.1.0"
+    "@jwiedeman/gtm-kit": "workspace:*"
   },
   "peerDependencies": {
     "next": "^13.4.0 || ^14.0.0 || ^15.0.0",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -41,8 +41,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jwiedeman/gtm-kit": "^0.1.0",
-    "@jwiedeman/gtm-kit-vue": "^0.1.0"
+    "@jwiedeman/gtm-kit": "workspace:*",
+    "@jwiedeman/gtm-kit-vue": "workspace:*"
   },
   "peerDependencies": {
     "nuxt": "^3.0.0",

--- a/packages/react-legacy/package.json
+++ b/packages/react-legacy/package.json
@@ -40,7 +40,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jwiedeman/gtm-kit": "^0.1.0"
+    "@jwiedeman/gtm-kit": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/react-modern/package.json
+++ b/packages/react-modern/package.json
@@ -40,7 +40,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jwiedeman/gtm-kit": "^0.1.0"
+    "@jwiedeman/gtm-kit": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -40,7 +40,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jwiedeman/gtm-kit": "^0.1.0"
+    "@jwiedeman/gtm-kit": "workspace:*"
   },
   "peerDependencies": {
     "@remix-run/react": "^2.0.0",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -42,7 +42,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jwiedeman/gtm-kit": "^0.1.0"
+    "@jwiedeman/gtm-kit": "workspace:*"
   },
   "peerDependencies": {
     "solid-js": "^1.0.0"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -42,7 +42,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jwiedeman/gtm-kit": "^0.1.0"
+    "@jwiedeman/gtm-kit": "workspace:*"
   },
   "peerDependencies": {
     "svelte": "^4.0.0 || ^5.0.0"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jwiedeman/gtm-kit": "^0.1.0"
+    "@jwiedeman/gtm-kit": "workspace:*"
   },
   "peerDependencies": {
     "vue": "^3.3.0"


### PR DESCRIPTION
The v1.0.0 release commit incorrectly changed workspace:* dependencies to ^0.1.0 in package.json files. This caused lockfile mismatches in CI because pnpm-lock.yaml still referenced workspace:*.

Restored all inter-package dependencies back to workspace:* protocol.