### PR TITLE
Comprehensive security and performance review

### DIFF
--- a/packages/astro/src/__tests__/client.spec.ts
+++ b/packages/astro/src/__tests__/client.spec.ts
@@ -51,12 +51,19 @@ describe('Astro GTM Client', () => {
       expect(createGtmClient).toHaveBeenCalledTimes(1);
     });
 
-    it('should teardown and create new client if config changes', () => {
-      initGtm({ containers: 'GTM-TEST123' });
-      initGtm({ containers: 'GTM-DIFFERENT' });
+    it('should return existing client even with different config (idempotent)', () => {
+      // In Astro with view transitions, initGtm may be called multiple times
+      // It should always return the existing client to prevent duplicate initialization
+      const client1 = initGtm({ containers: 'GTM-TEST123' });
 
-      expect(mockClient.teardown).toHaveBeenCalled();
-      expect(createGtmClient).toHaveBeenCalledTimes(2);
+      // Clear mocks after first init so we can check that second call doesn't create new client
+      jest.clearAllMocks();
+
+      const client2 = initGtm({ containers: 'GTM-DIFFERENT' });
+
+      expect(client1).toBe(client2);
+      expect(createGtmClient).not.toHaveBeenCalled(); // Should not create new client
+      expect(mockClient.teardown).not.toHaveBeenCalled(); // Should not teardown existing client
     });
   });
 

--- a/packages/astro/src/client.ts
+++ b/packages/astro/src/client.ts
@@ -24,13 +24,10 @@ let clientConfig: CreateGtmClientOptions | null = null;
  * ```
  */
 export const initGtm = (options: CreateGtmClientOptions): GtmClient => {
-  if (clientInstance && clientConfig) {
-    // If already initialized with same config, return existing instance
-    if (JSON.stringify(clientConfig) === JSON.stringify(options)) {
-      return clientInstance;
-    }
-    // Teardown existing client if config changed
-    clientInstance.teardown();
+  // If already initialized, return existing instance
+  // (common in Astro with view transitions where initGtm may be called multiple times)
+  if (clientInstance) {
+    return clientInstance;
   }
 
   clientInstance = createGtmClient(options);

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -28,4 +28,4 @@ export type {
 } from '@jwiedeman/gtm-kit';
 
 // Re-export consent helpers
-export { consentPresets, getConsentPreset } from '@jwiedeman/gtm-kit';
+export { consentPresets, getConsentPreset, eeaDefault, allGranted, analyticsOnly } from '@jwiedeman/gtm-kit';

--- a/packages/core/src/__tests__/consent.spec.ts
+++ b/packages/core/src/__tests__/consent.spec.ts
@@ -4,7 +4,10 @@ import {
   consentPresets,
   createConsentDefaultsCommand,
   createConsentUpdateCommand,
-  getConsentPreset
+  getConsentPreset,
+  eeaDefault,
+  allGranted,
+  analyticsOnly
 } from '../../src';
 
 describe('consent helpers', () => {
@@ -67,16 +70,8 @@ describe('consent helpers', () => {
 
   it('creates typed consent helpers for defaults and updates', () => {
     expect(
-      createConsentDefaultsCommand(
-        { analytics_storage: 'denied' },
-        { region: ['EEA'], waitForUpdate: 1000 }
-      )
-    ).toEqual([
-      'consent',
-      'default',
-      { analytics_storage: 'denied' },
-      { region: ['EEA'], wait_for_update: 1000 }
-    ]);
+      createConsentDefaultsCommand({ analytics_storage: 'denied' }, { region: ['EEA'], waitForUpdate: 1000 })
+    ).toEqual(['consent', 'default', { analytics_storage: 'denied' }, { region: ['EEA'], wait_for_update: 1000 }]);
 
     expect(createConsentUpdateCommand({ ad_personalization: 'granted' })).toEqual([
       'consent',
@@ -112,5 +107,20 @@ describe('consent helpers', () => {
     expect(Object.isFrozen(clone)).toBe(false);
     clone.ad_storage = 'denied';
     expect(consentPresets.allGranted.ad_storage).toBe('granted');
+  });
+
+  it('exports convenience preset references', () => {
+    // Verify direct exports match the presets object
+    expect(eeaDefault).toBe(consentPresets.eeaDefault);
+    expect(allGranted).toBe(consentPresets.allGranted);
+    expect(analyticsOnly).toBe(consentPresets.analyticsOnly);
+
+    // Verify the content
+    expect(eeaDefault.ad_storage).toBe('denied');
+    expect(eeaDefault.analytics_storage).toBe('denied');
+    expect(allGranted.ad_storage).toBe('granted');
+    expect(allGranted.analytics_storage).toBe('granted');
+    expect(analyticsOnly.analytics_storage).toBe('granted');
+    expect(analyticsOnly.ad_storage).toBe('denied');
   });
 });

--- a/packages/core/src/consent/presets.ts
+++ b/packages/core/src/consent/presets.ts
@@ -92,3 +92,21 @@ export type ConsentPresetName = keyof typeof consentPresets;
 export const getConsentPreset = (name: ConsentPresetName): ConsentState => ({
   ...consentPresets[name]
 });
+
+/**
+ * Convenience export for the EEA default consent state.
+ * All categories denied - GDPR/EEA compliant default.
+ */
+export const eeaDefault = consentPresets.eeaDefault;
+
+/**
+ * Convenience export for the all-granted consent state.
+ * All categories granted - user accepts all tracking.
+ */
+export const allGranted = consentPresets.allGranted;
+
+/**
+ * Convenience export for the analytics-only consent state.
+ * Analytics allowed, advertising denied.
+ */
+export const analyticsOnly = consentPresets.analyticsOnly;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ export type {
 export { DEFAULT_DATA_LAYER_NAME, DEFAULT_GTM_HOST } from './constants';
 export type { ConsentCommand, ConsentRegionOptions, ConsentState } from './consent';
 export { buildConsentCommand, consent, createConsentDefaultsCommand, createConsentUpdateCommand } from './consent';
-export { consentPresets, getConsentPreset } from './consent/presets';
+export { consentPresets, getConsentPreset, eeaDefault, allGranted, analyticsOnly } from './consent/presets';
 export { createGtmClient } from './client';
 export { pushEvent, pushEcommerce } from './events';
 export { createNoscriptMarkup, DEFAULT_NOSCRIPT_IFRAME_ATTRIBUTES } from './noscript';

--- a/packages/core/src/noscript.ts
+++ b/packages/core/src/noscript.ts
@@ -1,6 +1,5 @@
 import type { ContainerConfigInput, ContainerDescriptor } from './types';
-
-const DEFAULT_HOST = 'https://www.googletagmanager.com';
+import { DEFAULT_GTM_HOST } from './constants';
 const DEFAULT_IFRAME_ATTRIBUTES: Record<string, string> = {
   height: '0',
   width: '0',
@@ -18,9 +17,7 @@ const normalizeContainer = (input: ContainerConfigInput): ContainerDescriptor =>
   return input;
 };
 
-const toRecord = (
-  params?: Record<string, string | number | boolean>
-): Record<string, string> => {
+const toRecord = (params?: Record<string, string | number | boolean>): Record<string, string> => {
   if (!params) {
     return {};
   }
@@ -32,11 +29,7 @@ const toRecord = (
 };
 
 const escapeAttributeValue = (value: string): string =>
-  value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+  value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 const buildNoscriptUrl = (
   host: string,
@@ -57,9 +50,7 @@ const buildNoscriptUrl = (
   return `${normalizedHost}/ns.html?${searchParams.toString()}`;
 };
 
-const buildAttributeString = (
-  attributes: Record<string, string | number | boolean> | undefined
-): string => {
+const buildAttributeString = (attributes: Record<string, string | number | boolean> | undefined): string => {
   if (!attributes) {
     return '';
   }
@@ -69,9 +60,7 @@ const buildAttributeString = (
     return '';
   }
 
-  return entries
-    .map(([key, value]) => `${key}="${escapeAttributeValue(String(value))}"`)
-    .join(' ');
+  return entries.map(([key, value]) => `${key}="${escapeAttributeValue(String(value))}"`).join(' ');
 };
 
 export interface NoscriptOptions {
@@ -80,15 +69,12 @@ export interface NoscriptOptions {
   iframeAttributes?: Record<string, string | number | boolean>;
 }
 
-const buildNoscriptForContainer = (
-  container: ContainerDescriptor,
-  options: NoscriptOptions
-): string => {
+const buildNoscriptForContainer = (container: ContainerDescriptor, options: NoscriptOptions): string => {
   if (!container.id) {
     throw new Error('Container id is required to build noscript markup.');
   }
 
-  const host = options.host ?? DEFAULT_HOST;
+  const host = options.host ?? DEFAULT_GTM_HOST;
   const params = {
     ...options.defaultQueryParams,
     ...container.queryParams
@@ -117,9 +103,7 @@ export const createNoscriptMarkup = (
     throw new Error('At least one container is required to build noscript markup.');
   }
 
-  return normalizedContainers
-    .map((container) => buildNoscriptForContainer(container, options))
-    .join('');
+  return normalizedContainers.map((container) => buildNoscriptForContainer(container, options)).join('');
 };
 
 export const DEFAULT_NOSCRIPT_IFRAME_ATTRIBUTES = { ...DEFAULT_IFRAME_ATTRIBUTES };

--- a/packages/next/src/internal/container-helpers.ts
+++ b/packages/next/src/internal/container-helpers.ts
@@ -1,7 +1,8 @@
-import { DEFAULT_DATA_LAYER_NAME } from '@jwiedeman/gtm-kit';
+import { DEFAULT_DATA_LAYER_NAME, DEFAULT_GTM_HOST } from '@jwiedeman/gtm-kit';
 import type { ContainerConfigInput, ContainerDescriptor } from '@jwiedeman/gtm-kit';
 
-export const DEFAULT_GTM_HOST = 'https://www.googletagmanager.com';
+// Re-export for convenience
+export { DEFAULT_GTM_HOST };
 
 const isString = (value: unknown): value is string => typeof value === 'string';
 

--- a/packages/nuxt/src/index.ts
+++ b/packages/nuxt/src/index.ts
@@ -29,4 +29,4 @@ export type {
   ScriptLoadState
 } from '@jwiedeman/gtm-kit';
 
-export { consentPresets, pushEvent, pushEcommerce } from '@jwiedeman/gtm-kit';
+export { consentPresets, eeaDefault, allGranted, analyticsOnly, pushEvent, pushEcommerce } from '@jwiedeman/gtm-kit';


### PR DESCRIPTION
- Add direct exports for consent presets (eeaDefault, allGranted, analyticsOnly) to fix CLI codegen that was generating broken imports
- Remove duplicate DEFAULT_GTM_HOST constant definitions by importing from core
- Simplify Astro initGtm to be idempotent (return existing client instead of naive JSON config comparison)
- Update tests to match new behavior